### PR TITLE
Fujitatomoya/check task canceled

### DIFF
--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -155,3 +155,6 @@ class ROSInterruptException(Exception):
 
     def __init__(self) -> None:
         Exception.__init__(self, 'rclpy.shutdown() has been called')
+
+class CancelledException(BaseException):
+    """The Future or Task was cancelled."""

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -321,14 +321,24 @@ class Executor(ContextManager['Executor']):
         future.add_done_callback(lambda x: self.wake())
 
         if timeout_sec is None or timeout_sec < 0:
-            while self._context.ok() and not future.done() and not self._is_shutdown:
+            while (
+                self._context.ok() and
+                not future.done() and
+                not future.cancelled()
+                and not self._is_shutdown
+            ):
                 self._spin_once_until_future_complete(future, timeout_sec)
         else:
             start = time.monotonic()
             end = start + timeout_sec
             timeout_left = TimeoutObject(timeout_sec)
 
-            while self._context.ok() and not future.done() and not self._is_shutdown:
+            while (
+                self._context.ok() and
+                not future.done() and
+                not future.cancelled()
+                and not self._is_shutdown
+            ):
                 self._spin_once_until_future_complete(future, timeout_left)
                 now = time.monotonic()
 
@@ -610,6 +620,8 @@ class Executor(ContextManager['Executor']):
                 with self._tasks_lock:
                     # Get rid of any tasks that are done
                     self._tasks = list(filter(lambda t_e_n: not t_e_n[0].done(), self._tasks))
+                    # Get rid of any tasks that are cancelled
+                    self._tasks = list(filter(lambda t_e_n: not t_e_n[0].cancelled(), self._tasks))
 
             # Gather entities that can be waited on
             subscriptions: List[Subscription] = []

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -61,7 +61,7 @@ class Future(Generic[T]):
 
     def __await__(self) -> Generator[None, None, Optional[T]]:
         # Yield if the task is not finished
-        while not self._done:
+        while not self._done and not self._cancelled:
             yield
         return self.result()
 
@@ -239,7 +239,12 @@ class Task(Future[T]):
 
         The return value of the handler is stored as the task result.
         """
-        if self._done or self._executing or not self._task_lock.acquire(blocking=False):
+        if (
+            self._done or
+            self._cancelled or
+            self._executing or
+            not self._task_lock.acquire(blocking=False)
+        ):
             return
         try:
             if self._done:

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -86,7 +86,7 @@ class Future(Generic[T]):
 
         :return: True if the task was cancelled
         """
-        return self._state != FutureState.CANCELLED
+        return self._state == FutureState.CANCELLED
 
     def done(self) -> bool:
         """

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -68,7 +68,7 @@ class Future(Generic[T]):
 
     def __await__(self) -> Generator[None, None, Optional[T]]:
         # Yield if the task is not finished
-        while self._state == FutureState.PENDING:
+        while not self.done():
             yield
         return self.result()
 
@@ -104,7 +104,7 @@ class Future(Generic[T]):
 
         :return: The result set by the task, or None if no result was set.
         """
-        exception = self.exception()
+        exception = CancelledException() if self.cancelled() else self.exception()
         if exception:
             raise exception
         return self._result

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -15,7 +15,6 @@
 import inspect
 import sys
 import threading
-from tkinter import E
 from typing import (Callable, cast, Coroutine, Dict, Generator, Generic, List,
                     Optional, TYPE_CHECKING, TypeVar, Union)
 import warnings

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -19,7 +19,7 @@ from typing import (Callable, cast, Coroutine, Dict, Generator, Generic, List,
                     Optional, TYPE_CHECKING, TypeVar, Union)
 import warnings
 import weakref
-
+from enum import StrEnum, auto
 if TYPE_CHECKING:
     from rclpy.executors import Executor
 
@@ -31,14 +31,18 @@ def _fake_weakref() -> None:
     return None
 
 
+class FutureState(StrEnum):
+    """States defining the lifecycle of a future"""
+    PENDING = auto()
+    CANCELLED = auto()
+    FINISHED = auto()
+
+
 class Future(Generic[T]):
     """Represent the outcome of a task in the future."""
 
     def __init__(self, *, executor: Optional['Executor'] = None) -> None:
-        # true if the task is done or cancelled
-        self._done = False
-        # true if the task is cancelled
-        self._cancelled = False
+        self._state = FutureState.PENDING
         # the final return value of the handler
         self._result: Optional[T] = None
         # An exception raised by the handler when called
@@ -61,15 +65,15 @@ class Future(Generic[T]):
 
     def __await__(self) -> Generator[None, None, Optional[T]]:
         # Yield if the task is not finished
-        while not self._done and not self._cancelled:
+        while self._state == FutureState.PENDING:
             yield
         return self.result()
 
     def cancel(self) -> None:
         """Request cancellation of the running task if it is not done already."""
         with self._lock:
-            if not self._done:
-                self._cancelled = True
+            if not self.done():
+                self._state = FutureState.CANCELLED
         self._schedule_or_invoke_done_callbacks()
 
     def cancelled(self) -> bool:
@@ -78,7 +82,7 @@ class Future(Generic[T]):
 
         :return: True if the task was cancelled
         """
-        return self._cancelled
+        return self._state != FutureState.CANCELLED
 
     def done(self) -> bool:
         """
@@ -86,7 +90,7 @@ class Future(Generic[T]):
 
         :return: True if the task is finished or raised while it was executing
         """
-        return self._done
+        return self._state != FutureState.PENDING
 
     def result(self) -> Optional[T]:
         """
@@ -118,8 +122,7 @@ class Future(Generic[T]):
         """
         with self._lock:
             self._result = result
-            self._done = True
-            self._cancelled = False
+            self._state = FutureState.FINISHED
         self._schedule_or_invoke_done_callbacks()
 
     def set_exception(self, exception: Exception) -> None:
@@ -131,8 +134,7 @@ class Future(Generic[T]):
         with self._lock:
             self._exception = exception
             self._exception_fetched = False
-            self._done = True
-            self._cancelled = False
+            self._state = FutureState.FINISHED
         self._schedule_or_invoke_done_callbacks()
 
     def _schedule_or_invoke_done_callbacks(self) -> None:
@@ -181,7 +183,7 @@ class Future(Generic[T]):
         """
         invoke = False
         with self._lock:
-            if self._done:
+            if self.done():
                 assert self._executor is not None
                 executor = self._executor()
                 if executor is not None:
@@ -240,14 +242,13 @@ class Task(Future[T]):
         The return value of the handler is stored as the task result.
         """
         if (
-            self._done or
-            self._cancelled or
+            self._state != FutureState.PENDING or
             self._executing or
             not self._task_lock.acquire(blocking=False)
         ):
             return
         try:
-            if self._done:
+            if self.done():
                 return
             self._executing = True
 

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -273,6 +273,27 @@ class TestExecutor(unittest.TestCase):
         self.assertTrue(future.done())
         self.assertEqual('Sentinel Result', future.result())
 
+    def test_create_task_coroutine_cancel(self) -> None:
+        self.assertIsNotNone(self.node.handle)
+        executor = SingleThreadedExecutor(context=self.context)
+        executor.add_node(self.node)
+
+        async def coroutine():
+            await asyncio.sleep(1)
+            return 'Sentinel Result'
+
+        future = executor.create_task(coroutine)
+        self.assertFalse(future.done())
+        self.assertFalse(future.cancelled())
+
+        future.cancel()
+        self.assertTrue(future.cancelled())
+
+        executor.spin_until_future_complete(future)
+        self.assertFalse(future.done())
+        self.assertTrue(future.cancelled())
+        self.assertEqual(None, future.result())
+
     def test_create_task_normal_function(self) -> None:
         self.assertIsNotNone(self.node.handle)
         executor = SingleThreadedExecutor(context=self.context)


### PR DESCRIPTION
3 options to deal with the executor crashing:
1. task does not raise CancelledError in result() if cancelled
2. executor ignores CancelledError exceptions
3. in __await__ set self._is_awaited flag and do not raise CancelledError in the executor if awaited
4. switch to ExceptionHandler like asyncio