### PR TITLE
Refactor: move Node initialization to BaseNode

### DIFF
--- a/rclpy/rclpy/logging_service.py
+++ b/rclpy/rclpy/logging_service.py
@@ -23,12 +23,12 @@ from rclpy.qos import qos_profile_services_default
 from rclpy.validate_topic_name import TOPIC_SEPARATOR_STRING
 
 if TYPE_CHECKING:
-    from rclpy.node import Node
+    from rclpy.node import BaseNode
 
 
 class LoggingService:
 
-    def __init__(self, node: 'Node'):
+    def __init__(self, node: 'BaseNode'):
         node_name = node.get_name()
 
         get_logger_name_service_name = \

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -89,7 +89,7 @@ from rclpy.qos_overriding_options import QoSOverridingOptions
 from rclpy.service import BaseService
 from rclpy.service import Service
 from rclpy.service import ServiceCallbackUnion
-from rclpy.subscription import GenericSubscriptionCallbackUnion
+from rclpy.subscription import BaseSubscription, GenericSubscriptionCallbackUnion
 from rclpy.subscription import Subscription
 from rclpy.subscription import SubscriptionCallbackUnion
 from rclpy.subscription_content_filter_options import ContentFilterOptions
@@ -148,7 +148,11 @@ class BaseNode(ABC):
         use_global_arguments: bool = True,
         enable_rosout: bool = True,
         rosout_qos_profile: Union[QoSProfile, int] = qos_profile_rosout_default,
+        start_parameter_services: bool = True,
+        parameter_overrides: Optional[List[Parameter[Any]]] = None,
         allow_undeclared_parameters: bool = False,
+        automatically_declare_parameters_from_overrides: bool = False,
+        enable_logger_service: bool = False,
     ) -> None:
         self._context = get_default_context() if context is None else context
         self._parameters: Dict[str, Parameter[Any]] = {}
@@ -160,7 +164,6 @@ class BaseNode(ABC):
         self._allow_undeclared_parameters = allow_undeclared_parameters
         self._parameter_overrides: Dict[str, Parameter[Any]] = {}
         self._descriptors: Dict[str, ParameterDescriptor] = {}
-        self._parameter_event_publisher: Optional[BasePublisher[ParameterEvent]] = None
 
         namespace = namespace or ''
 
@@ -195,6 +198,42 @@ class BaseNode(ABC):
         with self.handle:
             self._logger = get_logger(self.__node.logger_name())
 
+        self._parameter_event_publisher: Optional[BasePublisher[ParameterEvent]] = \
+            self.create_publisher(ParameterEvent, '/parameter_events',
+                                  qos_profile_parameter_events)
+
+        with self.handle:
+            self._parameter_overrides = self.handle.get_parameters(Parameter)
+        # Combine parameters from params files with those from the node constructor and
+        # use the set_parameters_atomically API so a parameter event is published.
+        if parameter_overrides is not None:
+            self._parameter_overrides.update({p.name: p for p in parameter_overrides})
+
+        if automatically_declare_parameters_from_overrides:
+            self.declare_parameters(
+                '',
+                [
+                    (name, param.value, ParameterDescriptor())
+                    for name, param in self._parameter_overrides.items()],
+                ignore_override=True,
+            )
+
+        # Init a time source.
+        # Note: parameter overrides and parameter event publisher need to be ready at this point
+        # to be able to declare 'use_sim_time' if it was not declared yet.
+        self._time_source = TimeSource(node=self)
+        self._time_source.attach_clock(self.get_clock())
+
+        if start_parameter_services:
+            self._parameter_service = ParameterService(self)
+
+        if enable_logger_service:
+            self._logger_service = LoggingService(self)
+
+        self._type_description_service = TypeDescriptionService(self)
+
+        self._context.track_node(self)
+
     @property
     def context(self) -> Context:
         """Get the context associated with the node."""
@@ -227,6 +266,47 @@ class BaseNode(ABC):
 
     @abstractmethod
     def get_clock(self) -> BaseClock:
+        ...
+
+    @abstractmethod
+    def create_publisher(
+        self,
+        msg_type: Type[MsgT],
+        topic: str,
+        qos_profile: Union[QoSProfile, int],
+    ) -> BasePublisher[MsgT]:
+        ...
+
+    @abstractmethod
+    def create_subscription(
+        self,
+        msg_type: Type[MsgT],
+        topic: str,
+        callback: SubscriptionCallbackUnion[MsgT],
+        qos_profile: Union[QoSProfile, int],
+    ) -> BaseSubscription[MsgT]:
+        ...
+
+    @abstractmethod
+    def create_service(
+        self,
+        srv_type: type[Srv[SrvRequestT, SrvResponseT]],
+        srv_name: str,
+        callback: ServiceCallbackUnion[SrvRequestT, SrvResponseT],
+        *,
+        qos_profile: QoSProfile = qos_profile_services_default,
+    ) -> BaseService[SrvRequestT, SrvResponseT]:
+        ...
+
+    @abstractmethod
+    def _create_service(
+        self,
+        service_impl: '_rclpy.Service[SrvRequestT, SrvResponseT]',
+        srv_type: type[Srv[SrvRequestT, SrvResponseT]],
+        srv_name: str,
+        callback: ServiceCallbackUnion[SrvRequestT, SrvResponseT],
+        qos_profile: QoSProfile,
+    ) -> BaseService[SrvRequestT, SrvResponseT]:
         ...
 
     def get_logger(self) -> RcutilsLogger:
@@ -1837,7 +1917,133 @@ class BaseNode(ABC):
             no_mangle,
             _rclpy.rclpy_get_servers_info_by_service)
 
+    def _create_publisher_handle(
+        self,
+        msg_type: Type[MsgT],
+        topic: str,
+        qos_profile: Union[QoSProfile, int],
+        *,
+        qos_overriding_options: Optional[QoSOverridingOptions] = None,
+    ) -> '_rclpy.Publisher[MsgT]':
+        try:
+            final_topic = self.resolve_topic_name(topic)
+        except RuntimeError:
+            # if it's name validation error, raise a more appropriate exception.
+            try:
+                self._validate_topic_or_service_name(topic)
+            except InvalidTopicNameException as ex:
+                raise ex from None
+            # else reraise the previous exception
+            raise
+
+        if qos_overriding_options is None:
+            qos_overriding_options = QoSOverridingOptions([])
+        _declare_qos_parameters(
+            Publisher, self, final_topic, qos_profile, qos_overriding_options)
+
+        # this line imports the typesupport for the message module if not already done
+        failed = False
+        check_is_valid_msg_type(msg_type)
+        try:
+            with self.handle:
+                publisher_object = _rclpy.Publisher(
+                    self.handle, msg_type, topic, qos_profile.get_c_qos_profile())
+        except ValueError:
+            failed = True
+        if failed:
+            self._validate_topic_or_service_name(topic)
+
+        return publisher_object
+
+    def _create_subscription_handle(
+        self,
+        msg_type: Type[MsgT],
+        topic: str,
+        qos_profile: QoSProfile,
+        *,
+        qos_overriding_options: Optional[QoSOverridingOptions] = None,
+        content_filter_options: Optional[ContentFilterOptions] = None,
+        acceptable_buffer_backends: Optional[str] = None
+    ) -> '_rclpy.Subscription[MsgT]':
+        try:
+            final_topic = self.resolve_topic_name(topic)
+        except RuntimeError:
+            # if it's name validation error, raise a more appropriate exception.
+            try:
+                self._validate_topic_or_service_name(topic)
+            except InvalidTopicNameException as ex:
+                raise ex from None
+            # else reraise the previous exception
+            raise
+
+        if qos_overriding_options is None:
+            qos_overriding_options = QoSOverridingOptions([])
+        _declare_qos_parameters(
+            Subscription, self, final_topic, qos_profile, qos_overriding_options)
+
+        # this line imports the typesupport for the message module if not already done
+        failed = False
+        check_is_valid_msg_type(msg_type)
+        try:
+            with self.handle:
+                subscription_object = _rclpy.Subscription(
+                    self.handle, msg_type, topic, qos_profile.get_c_qos_profile(),
+                    content_filter_options, acceptable_buffer_backends)
+        except ValueError:
+            failed = True
+        if failed:
+            self._validate_topic_or_service_name(topic)
+
+        return subscription_object
+
+    def _create_service_handle(
+        self,
+        srv_type: type[Srv[SrvRequestT, SrvResponseT]],
+        srv_name: str,
+        *,
+        qos_profile: QoSProfile = qos_profile_services_default,
+    ) -> '_rclpy.Service[SrvRequestT, SrvResponseT]':
+        check_is_valid_srv_type(srv_type)
+        failed = False
+        try:
+            with self.handle:
+                service_impl: '_rclpy.Service[SrvRequestT, SrvResponseT]' = _rclpy.Service(
+                    self.handle,
+                    srv_type,
+                    srv_name,
+                    qos_profile.get_c_qos_profile())
+        except ValueError:
+            failed = True
+        if failed:
+            self._validate_topic_or_service_name(srv_name, is_service=True)
+
+        return service_impl
+
+    def _create_client_handle(
+        self,
+        srv_type: type[Srv[SrvRequestT, SrvResponseT]],
+        srv_name: str,
+        *,
+        qos_profile: QoSProfile = qos_profile_services_default,
+    ) -> '_rclpy.Client[SrvRequestT, SrvResponseT]':
+        check_is_valid_srv_type(srv_type)
+        failed = False
+        try:
+            with self.handle:
+                client_impl = _rclpy.Client(
+                    self.handle,
+                    srv_type,
+                    srv_name,
+                    qos_profile.get_c_qos_profile())
+        except ValueError:
+            failed = True
+        if failed:
+            self._validate_topic_or_service_name(srv_name, is_service=True)
+
+        return client_impl
+
     def destroy_node(self) -> None:
+        self._context.untrack_node(self)
         self._parameter_event_publisher = None
         self.handle.destroy_when_not_in_use()
 
@@ -1916,44 +2122,13 @@ class Node(BaseNode):
             use_global_arguments=use_global_arguments,
             enable_rosout=enable_rosout,
             rosout_qos_profile=rosout_qos_profile,
+            start_parameter_services=start_parameter_services,
+            parameter_overrides=parameter_overrides,
             allow_undeclared_parameters=allow_undeclared_parameters,
+            automatically_declare_parameters_from_overrides=(
+                automatically_declare_parameters_from_overrides),
+            enable_logger_service=enable_logger_service,
         )
-
-        self._parameter_event_publisher: Optional[Publisher[ParameterEvent]] = \
-            self.create_publisher(ParameterEvent, '/parameter_events',
-                                  qos_profile_parameter_events)
-
-        with self.handle:
-            self._parameter_overrides = self.handle.get_parameters(Parameter)
-        # Combine parameters from params files with those from the node constructor and
-        # use the set_parameters_atomically API so a parameter event is published.
-        if parameter_overrides is not None:
-            self._parameter_overrides.update({p.name: p for p in parameter_overrides})
-
-        if automatically_declare_parameters_from_overrides:
-            self.declare_parameters(
-                '',
-                [
-                    (name, param.value, ParameterDescriptor())
-                    for name, param in self._parameter_overrides.items()],
-                ignore_override=True,
-            )
-
-        # Init a time source.
-        # Note: parameter overrides and parameter event publisher need to be ready at this point
-        # to be able to declare 'use_sim_time' if it was not declared yet.
-        self._time_source = TimeSource(node=self)
-        self._time_source.attach_clock(self._clock)
-
-        if start_parameter_services:
-            self._parameter_service = ParameterService(self)
-
-        if enable_logger_service:
-            self._logger_service = LoggingService(self)
-
-        self._type_description_service = TypeDescriptionService(self)
-
-        self._context.track_node(self)
 
     @property
     def publishers(self) -> Iterator[Publisher[Any]]:
@@ -2077,34 +2252,12 @@ class Node(BaseNode):
 
         callback_group = callback_group or self.default_callback_group
 
-        failed = False
-        try:
-            final_topic = self.resolve_topic_name(topic)
-        except RuntimeError:
-            # if it's name validation error, raise a more appropriate exception.
-            try:
-                self._validate_topic_or_service_name(topic)
-            except InvalidTopicNameException as ex:
-                raise ex from None
-            # else reraise the previous exception
-            raise
-
-        if qos_overriding_options is None:
-            qos_overriding_options = QoSOverridingOptions([])
-        _declare_qos_parameters(
-            Publisher, self, final_topic, qos_profile, qos_overriding_options)
-
-        # this line imports the typesupport for the message module if not already done
-        failed = False
-        check_is_valid_msg_type(msg_type)
-        try:
-            with self.handle:
-                publisher_object = _rclpy.Publisher(
-                    self.handle, msg_type, topic, qos_profile.get_c_qos_profile())
-        except ValueError:
-            failed = True
-        if failed:
-            self._validate_topic_or_service_name(topic)
+        publisher_object = self._create_publisher_handle(
+            msg_type,
+            topic,
+            qos_profile,
+            qos_overriding_options=qos_overriding_options
+        )
 
         try:
             publisher = publisher_class(
@@ -2210,34 +2363,14 @@ class Node(BaseNode):
 
         callback_group = callback_group or self.default_callback_group
 
-        try:
-            final_topic = self.resolve_topic_name(topic)
-        except RuntimeError:
-            # if it's name validation error, raise a more appropriate exception.
-            try:
-                self._validate_topic_or_service_name(topic)
-            except InvalidTopicNameException as ex:
-                raise ex from None
-            # else reraise the previous exception
-            raise
-
-        if qos_overriding_options is None:
-            qos_overriding_options = QoSOverridingOptions([])
-        _declare_qos_parameters(
-            Subscription, self, final_topic, qos_profile, qos_overriding_options)
-
-        # this line imports the typesupport for the message module if not already done
-        failed = False
-        check_is_valid_msg_type(msg_type)
-        try:
-            with self.handle:
-                subscription_object = _rclpy.Subscription(
-                    self.handle, msg_type, topic, qos_profile.get_c_qos_profile(),
-                    content_filter_options, acceptable_buffer_backends)
-        except ValueError:
-            failed = True
-        if failed:
-            self._validate_topic_or_service_name(topic)
+        subscription_object = self._create_subscription_handle(
+            msg_type,
+            topic,
+            qos_profile,
+            qos_overriding_options=qos_overriding_options,
+            content_filter_options=content_filter_options,
+            acceptable_buffer_backends=acceptable_buffer_backends
+        )
 
         try:
             subscription = Subscription(
@@ -2277,19 +2410,12 @@ class Node(BaseNode):
         """
         if callback_group is None:
             callback_group = self.default_callback_group
-        check_is_valid_srv_type(srv_type)
-        failed = False
-        try:
-            with self.handle:
-                client_impl = _rclpy.Client(
-                    self.handle,
-                    srv_type,
-                    srv_name,
-                    qos_profile.get_c_qos_profile())
-        except ValueError:
-            failed = True
-        if failed:
-            self._validate_topic_or_service_name(srv_name, is_service=True)
+
+        client_impl = self._create_client_handle(
+            srv_type,
+            srv_name,
+            qos_profile=qos_profile
+        )
 
         client = Client(
             self.context,
@@ -2321,22 +2447,32 @@ class Node(BaseNode):
         :param callback_group: The callback group for the service server. If ``None``, then the
             default callback group for the node is used.
         """
+        service_impl = self._create_service_handle(
+            srv_type,
+            srv_name,
+            qos_profile=qos_profile
+        )
+
+        return self._create_service(
+            service_impl,
+            srv_type,
+            srv_name,
+            callback,
+            qos_profile,
+            callback_group
+            )
+
+    def _create_service(
+        self,
+        service_impl: '_rclpy.Service[SrvRequestT, SrvResponseT]',
+        srv_type: type[Srv[SrvRequestT, SrvResponseT]],
+        srv_name: str,
+        callback: ServiceCallbackUnion[SrvRequestT, SrvResponseT],
+        qos_profile: QoSProfile,
+        callback_group: Optional[CallbackGroup] = None,
+    ) -> Service[SrvRequestT, SrvResponseT]:
         if callback_group is None:
             callback_group = self.default_callback_group
-        check_is_valid_srv_type(srv_type)
-        failed = False
-        try:
-            with self.handle:
-                service_impl: '_rclpy.Service[SrvRequestT, SrvResponseT]' = _rclpy.Service(
-                    self.handle,
-                    srv_type,
-                    srv_name,
-                    qos_profile.get_c_qos_profile())
-        except ValueError:
-            failed = True
-        if failed:
-            self._validate_topic_or_service_name(srv_name, is_service=True)
-
         service = Service(
             service_impl,
             srv_type, srv_name, callback, qos_profile,

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 import math
 import time
 
@@ -51,7 +52,7 @@ from rclpy.callback_groups import CallbackGroup
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.client import BaseClient, Client
-from rclpy.clock import Clock
+from rclpy.clock import BaseClock, Clock
 from rclpy.clock_type import ClockType
 from rclpy.constants import S_TO_NS
 from rclpy.context import Context
@@ -78,7 +79,7 @@ from rclpy.logging_service import LoggingService
 from rclpy.parameter import (AllowableParameterValue, AllowableParameterValueT, Parameter,
                              PARAMETER_SEPARATOR_STRING)
 from rclpy.parameter_service import ParameterService
-from rclpy.publisher import Publisher
+from rclpy.publisher import BasePublisher, Publisher
 from rclpy.qos import qos_profile_parameter_events
 from rclpy.qos import qos_profile_rosout_default
 from rclpy.qos import qos_profile_services_default
@@ -129,13 +130,7 @@ NodeNameNonExistentError: TypeAlias = _rclpy.NodeNameNonExistentError
 ParameterInput: TypeAlias = Union[AllowableParameterValue, Parameter.Type, ParameterValue]
 
 
-class Node:
-    """
-    A Node in the ROS graph.
-
-    A Node is the primary entrypoint in a ROS system for communication.
-    It can be used to create ROS entities such as publishers, subscribers, services, etc.
-    """
+class BaseNode(ABC):
 
     PARAM_REL_TOL = 1e-6
     """
@@ -153,61 +148,19 @@ class Node:
         use_global_arguments: bool = True,
         enable_rosout: bool = True,
         rosout_qos_profile: Union[QoSProfile, int] = qos_profile_rosout_default,
-        start_parameter_services: bool = True,
-        parameter_overrides: Optional[List[Parameter[Any]]] = None,
         allow_undeclared_parameters: bool = False,
-        automatically_declare_parameters_from_overrides: bool = False,
-        enable_logger_service: bool = False
     ) -> None:
-        """
-        Create a Node.
-
-        :param node_name: A name to give to this node. Validated by :func:`validate_node_name`.
-        :param context: The context to be associated with, or ``None`` for the default global
-            context.
-        :param cli_args: A list of strings of command line args to be used only by this node.
-            These arguments are used to extract remappings used by the node and other ROS specific
-            settings, as well as user defined non-ROS arguments.
-        :param namespace: The namespace to which relative topic and service names will be prefixed.
-            Validated by :func:`validate_namespace`.
-        :param use_global_arguments: ``False`` if the node should ignore process-wide command line
-            args.
-        :param enable_rosout: ``False`` if the node should ignore rosout logging.
-        :param rosout_qos_profile: A QoSProfile or a history depth to apply to rosout publisher.
-            In the case that a history depth is provided, the QoS history is set to KEEP_LAST
-            the QoS history depth is set to the value of the parameter,
-            and all other QoS settings are set to their default value.
-        :param start_parameter_services: ``False`` if the node should not create parameter
-            services.
-        :param parameter_overrides: A list of overrides for initial values for parameters declared
-            on the node.
-        :param allow_undeclared_parameters: True if undeclared parameters are allowed.
-            This flag affects the behavior of parameter-related operations.
-        :param automatically_declare_parameters_from_overrides: If True, the "parameter overrides"
-            will be used to implicitly declare parameters on the node during creation.
-        :param enable_logger_service: ``True`` if ROS2 services are created to allow external nodes
-            to get and set logger levels of this node. Otherwise, logger levels are only managed
-            locally. That is, logger levels cannot be changed remotely.
-        """
         self._context = get_default_context() if context is None else context
         self._parameters: Dict[str, Parameter[Any]] = {}
-        self._publishers: List[Publisher[Any]] = []
-        self._subscriptions: List[Subscription[Any]] = []
-        self._clients: List[Client[Any, Any]] = []
-        self._services: List[Service[Any, Any]] = []
-        self._timers: List[Timer] = []
-        self._guards: List[GuardCondition] = []
-        self.__waitables: List[Waitable[Any]] = []
-        self._default_callback_group = MutuallyExclusiveCallbackGroup()
         self._pre_set_parameters_callbacks: List[Callable[[List[Parameter[Any]]],
                                                           List[Parameter[Any]]]] = []
         self._on_set_parameters_callbacks: \
             List[Callable[[List[Parameter[Any]]], SetParametersResult]] = []
         self._post_set_parameters_callbacks: List[Callable[[List[Parameter[Any]]], None]] = []
-        self._rate_group = ReentrantCallbackGroup()
         self._allow_undeclared_parameters = allow_undeclared_parameters
         self._parameter_overrides: Dict[str, Parameter[Any]] = {}
         self._descriptors: Dict[str, ParameterDescriptor] = {}
+        self._parameter_event_publisher: Optional[BasePublisher[ParameterEvent]] = None
 
         namespace = namespace or ''
 
@@ -238,125 +191,14 @@ class Node:
                 validate_namespace(namespace)
                 # Should not get to this point
                 raise RuntimeError('rclpy_create_node failed for unknown reason')
+
         with self.handle:
             self._logger = get_logger(self.__node.logger_name())
-
-        self.__executor_weakref: Optional[weakref.ReferenceType[Executor]] = None
-
-        self._parameter_event_publisher: Optional[Publisher[ParameterEvent]] = \
-            self.create_publisher(ParameterEvent, '/parameter_events',
-                                  qos_profile_parameter_events)
-
-        with self.handle:
-            self._parameter_overrides = self.__node.get_parameters(Parameter)
-        # Combine parameters from params files with those from the node constructor and
-        # use the set_parameters_atomically API so a parameter event is published.
-        if parameter_overrides is not None:
-            self._parameter_overrides.update({p.name: p for p in parameter_overrides})
-
-        # Clock that has support for ROS time.
-        self._clock = Clock(clock_type=ClockType.ROS_TIME)
-
-        if automatically_declare_parameters_from_overrides:
-            self.declare_parameters(
-                '',
-                [
-                    (name, param.value, ParameterDescriptor())
-                    for name, param in self._parameter_overrides.items()],
-                ignore_override=True,
-            )
-
-        # Init a time source.
-        # Note: parameter overrides and parameter event publisher need to be ready at this point
-        # to be able to declare 'use_sim_time' if it was not declared yet.
-        self._time_source = TimeSource(node=self)
-        self._time_source.attach_clock(self._clock)
-
-        if start_parameter_services:
-            self._parameter_service = ParameterService(self)
-
-        if enable_logger_service:
-            self._logger_service = LoggingService(self)
-
-        self._type_description_service = TypeDescriptionService(self)
-
-        self._context.track_node(self)
-
-    @property
-    def publishers(self) -> Iterator[Publisher[Any]]:
-        """Get publishers that have been created on this node."""
-        yield from self._publishers
-
-    @property
-    def subscriptions(self) -> Iterator[Subscription[Any]]:
-        """Get subscriptions that have been created on this node."""
-        yield from self._subscriptions
-
-    @property
-    def clients(self) -> Iterator[Client[Any, Any]]:
-        """Get clients that have been created on this node."""
-        yield from self._clients
-
-    @property
-    def services(self) -> Iterator[Service[Any, Any]]:
-        """Get services that have been created on this node."""
-        yield from self._services
-
-    @property
-    def timers(self) -> Iterator[Timer]:
-        """Get timers that have been created on this node."""
-        yield from self._timers
-
-    @property
-    def guards(self) -> Iterator[GuardCondition]:
-        """Get guards that have been created on this node."""
-        yield from self._guards
-
-    @property
-    def waitables(self) -> Iterator[Waitable[Any]]:
-        """Get waitables that have been created on this node."""
-        yield from self.__waitables
-
-    @property
-    def executor(self) -> Optional[Executor]:
-        """Get the executor if the node has been added to one, else return ``None``."""
-        if self.__executor_weakref:
-            return self.__executor_weakref()
-        return None
-
-    @executor.setter
-    def executor(self, new_executor: Optional[Executor]) -> None:
-        """Set or change the executor the node belongs to."""
-        current_executor = self.executor
-        if current_executor == new_executor:
-            return
-        if current_executor is not None:
-            current_executor.remove_node(self)
-        if new_executor is None:
-            self.__executor_weakref = None
-        else:
-            new_executor.add_node(self)
-            self.__executor_weakref = weakref.ref(new_executor)
-
-    def _wake_executor(self) -> None:
-        executor = self.executor
-        if executor:
-            executor.wake()
 
     @property
     def context(self) -> Context:
         """Get the context associated with the node."""
         return self._context
-
-    @property
-    def default_callback_group(self) -> CallbackGroup:
-        """
-        Get the default callback group.
-
-        If no other callback group is provided when the a ROS entity is created with the node,
-        then it is added to the default callback group.
-        """
-        return self._default_callback_group
 
     @property
     def handle(self) -> _rclpy.Node:
@@ -383,9 +225,9 @@ class Node:
         with self.handle:
             return self.handle.get_namespace()
 
-    def get_clock(self) -> Clock:
-        """Get the clock used by the node."""
-        return self._clock
+    @abstractmethod
+    def get_clock(self) -> BaseClock:
+        ...
 
     def get_logger(self) -> RcutilsLogger:
         """Get the nodes logger."""
@@ -1008,7 +850,7 @@ class Node:
                     # Descriptors have already been applied by this point.
                     self._parameters[param.name] = param
 
-            parameter_event.stamp = self._clock.now().to_msg()
+            parameter_event.stamp = self.get_clock().now().to_msg()
             if self._parameter_event_publisher:
                 self._parameter_event_publisher.publish(parameter_event)
 
@@ -1518,24 +1360,6 @@ class Node:
             raise TypeError(
                 'Expected QoSProfile or int, but received {!r}'.format(type(qos_or_depth)))
 
-    def add_waitable(self, waitable: Waitable[Any]) -> None:
-        """
-        Add a class that is capable of adding things to the wait set.
-
-        :param waitable: An instance of a waitable that the node will add to the waitset.
-        """
-        self.__waitables.append(waitable)
-        self._wake_executor()
-
-    def remove_waitable(self, waitable: Waitable[Any]) -> None:
-        """
-        Remove a Waitable that was previously added to the node.
-
-        :param waitable: The Waitable to remove.
-        """
-        self.__waitables.remove(waitable)
-        self._wake_executor()
-
     def resolve_topic_name(self, topic: str, *, only_expand: bool = False) -> str:
         """
         Return a topic name expanded and remapped.
@@ -1561,6 +1385,668 @@ class Node:
         """
         with self.handle:
             return _rclpy.rclpy_resolve_name(self.handle, service, only_expand, True)
+
+    def get_publisher_names_and_types_by_node(
+        self,
+        node_name: str,
+        node_namespace: str,
+        no_demangle: bool = False
+    ) -> List[Tuple[str, List[str]]]:
+        """
+        Get a list of discovered topics for publishers of a remote node.
+
+        :param node_name: Name of a remote node to get publishers for.
+        :param node_namespace: Namespace of the remote node.
+        :param no_demangle: If ``True``, then topic names and types returned will not be demangled.
+        :return: List of tuples.
+          The first element of each tuple is the topic name and the second element is a list of
+          topic types.
+        :raise NodeNameNonExistentError: If the node wasn't found.
+        :raise RuntimeError: Unexpected failure.
+        """
+        with self.handle:
+            return _rclpy.rclpy_get_publisher_names_and_types_by_node(
+                self.handle, no_demangle, node_name, node_namespace)
+
+    def get_subscriber_names_and_types_by_node(
+        self,
+        node_name: str,
+        node_namespace: str,
+        no_demangle: bool = False
+    ) -> List[Tuple[str, List[str]]]:
+        """
+        Get a list of discovered topics for subscriptions of a remote node.
+
+        :param node_name: Name of a remote node to get subscriptions for.
+        :param node_namespace: Namespace of the remote node.
+        :param no_demangle: If ``True``, then topic names and types returned will not be demangled.
+        :return: List of tuples.
+          The first element of each tuple is the topic name and the second element is a list of
+          topic types.
+        :raise NodeNameNonExistentError: If the node wasn't found.
+        :raise RuntimeError: Unexpected failure.
+        """
+        with self.handle:
+            return _rclpy.rclpy_get_subscriber_names_and_types_by_node(
+                self.handle, no_demangle, node_name, node_namespace)
+
+    def get_service_names_and_types_by_node(
+        self,
+        node_name: str,
+        node_namespace: str
+    ) -> List[Tuple[str, List[str]]]:
+        """
+        Get a list of discovered service servers for a remote node.
+
+        :param node_name: Name of a remote node to get services for.
+        :param node_namespace: Namespace of the remote node.
+        :return: List of tuples.
+          The first element of each tuple is the service server name
+          and the second element is a list of service types.
+        :raise NodeNameNonExistentError: If the node wasn't found.
+        :raise RuntimeError: Unexpected failure.
+        """
+        with self.handle:
+            return _rclpy.rclpy_get_service_names_and_types_by_node(
+                self.handle, node_name, node_namespace)
+
+    def get_client_names_and_types_by_node(
+        self,
+        node_name: str,
+        node_namespace: str
+    ) -> List[Tuple[str, List[str]]]:
+        """
+        Get a list of discovered service clients for a remote node.
+
+        :param node_name: Name of a remote node to get service clients for.
+        :param node_namespace: Namespace of the remote node.
+        :return: List of tuples.
+          The first element of each tuple is the service client name
+          and the second element is a list of service client types.
+        :raise NodeNameNonExistentError: If the node wasn't found.
+        :raise RuntimeError: Unexpected failure.
+        """
+        with self.handle:
+            return _rclpy.rclpy_get_client_names_and_types_by_node(
+                self.handle, node_name, node_namespace)
+
+    def get_action_client_names_and_types_by_node(
+        self,
+        node_name: str,
+        node_namespace: str
+    ) -> List[Tuple[str, List[str]]]:
+        """
+        Get a list of action names and types for action clients associated with a remote node.
+
+        :param node_name: Name of a remote node to get action clients for.
+        :param node_namespace: Namespace of the remote node.
+        :return: List of tuples.
+          The first element of each tuple is the action name and the second element is a list of
+          action types.
+        :raise NodeNameNonExistentError: If the node wasn't found.
+        :raise RuntimeError: Unexpected failure.
+        """
+        with self.handle:
+            return _rclpy.rclpy_get_action_client_names_and_types_by_node(
+                self.handle, node_name, node_namespace)
+
+    def get_action_server_names_and_types_by_node(
+        self,
+        node_name: str,
+        node_namespace: str
+    ) -> List[Tuple[str, List[str]]]:
+        """
+        Get a list of action names and types for action servers associated with a remote node.
+
+        :param node_name: Name of a remote node to get action servers for.
+        :param node_namespace: Namespace of the remote node.
+        :return: List of tuples.
+          The first element of each tuple is the action name and the second element is a list of
+          action types.
+        :raise NodeNameNonExistentError: If the node wasn't found.
+        :raise RuntimeError: Unexpected failure.
+        """
+        with self.handle:
+            return _rclpy.rclpy_get_action_server_names_and_types_by_node(
+                self.handle, node_name, node_namespace)
+
+    def get_action_names_and_types(self) -> List[Tuple[str, List[str]]]:
+        """
+        Get a list of action names and types in the ROS graph.
+
+        :return: List of tuples.
+          The first element of each tuple is the action name and the second element is a list of
+          action types.
+        """
+        with self.handle:
+            return _rclpy.rclpy_get_action_names_and_types(self.handle)
+
+    def get_topic_names_and_types(self, no_demangle: bool = False) -> List[Tuple[str, List[str]]]:
+        """
+        Get a list of discovered topic names and types.
+
+        :param no_demangle: If ``True``, then topic names and types returned will not be demangled.
+        :return: List of tuples.
+          The first element of each tuple is the topic name and the second element is a list of
+          topic types.
+        """
+        with self.handle:
+            return _rclpy.rclpy_get_topic_names_and_types(self.handle, no_demangle)
+
+    def get_service_names_and_types(self) -> List[Tuple[str, List[str]]]:
+        """
+        Get a list of discovered service names and types.
+
+        :return: List of tuples.
+          The first element of each tuple is the service name and the second element is a list of
+          service types.
+        """
+        with self.handle:
+            return _rclpy.rclpy_get_service_names_and_types(self.handle)
+
+    def get_node_names(self) -> List[str]:
+        """
+        Get a list of names for discovered nodes.
+
+        :return: List of node names.
+        """
+        with self.handle:
+            names_ns = self.handle.get_node_names_and_namespaces()
+        return [n[0] for n in names_ns]
+
+    def get_fully_qualified_node_names(self) -> List[str]:
+        """
+        Get a list of fully qualified names for discovered nodes.
+
+        Similar to ``get_node_names_namespaces()``, but concatenates the names and namespaces.
+
+        :return: List of fully qualified node names.
+        """
+        names_and_namespaces = self.get_node_names_and_namespaces()
+        return [
+            ns + ('' if ns.endswith('/') else '/') + name
+            for name, ns in names_and_namespaces
+        ]
+
+    def get_node_names_and_namespaces(self) -> List[Tuple[str, str]]:
+        """
+        Get a list of names and namespaces for discovered nodes.
+
+        :return: List of tuples containing two strings: the node name and node namespace.
+        """
+        with self.handle:
+            return self.handle.get_node_names_and_namespaces()
+
+    def get_node_names_and_namespaces_with_enclaves(self) -> List[Tuple[str, str, str]]:
+        """
+        Get a list of names, namespaces and enclaves for discovered nodes.
+
+        :return: List of tuples containing three strings: the node name, node namespace
+            and enclave.
+        """
+        with self.handle:
+            return self.handle.get_node_names_and_namespaces_with_enclaves()
+
+    def get_fully_qualified_name(self) -> str:
+        """
+        Get the node's fully qualified name.
+
+        :return: Fully qualified node name.
+        """
+        with self.handle:
+            return self.handle.get_fully_qualified_name()
+
+    def _count_publishers_or_subscribers(self, topic_name: str, func: Callable[[str], int]) -> int:
+        fq_topic_name = expand_topic_name(topic_name, self.get_name(), self.get_namespace())
+        validate_full_topic_name(fq_topic_name)
+        with self.handle:
+            return func(fq_topic_name)
+
+    def count_publishers(self, topic_name: str) -> int:
+        """
+        Return the number of publishers on a given topic.
+
+        ``topic_name`` may be a relative, private, or fully qualified topic name.
+        A relative or private topic is expanded using this node's namespace and name.
+        The queried topic name is not remapped.
+
+        :param topic_name: The topic name on which to count the number of publishers.
+        :return: The number of publishers on the topic.
+        """
+        with self.handle:
+            return self._count_publishers_or_subscribers(
+                topic_name, self.handle.get_count_publishers)
+
+    def count_subscribers(self, topic_name: str) -> int:
+        """
+        Return the number of subscribers on a given topic.
+
+        ``topic_name`` may be a relative, private, or fully qualified topic name.
+        A relative or private topic is expanded using this node's namespace and name.
+        The queried topic name is not remapped.
+
+        :param topic_name: The topic name on which to count the number of subscribers.
+        :return: The number of subscribers on the topic.
+        """
+        with self.handle:
+            return self._count_publishers_or_subscribers(
+                topic_name, self.handle.get_count_subscribers)
+
+    def _count_clients_or_servers(self, service_name: str, func: Callable[[str], int]) -> int:
+        fq_service_name = expand_topic_name(service_name, self.get_name(), self.get_namespace())
+        validate_full_topic_name(fq_service_name, is_service=True)
+        with self.handle:
+            return func(fq_service_name)
+
+    def count_clients(self, service_name: str) -> int:
+        """
+        Return the number of clients on a given service.
+
+        `service_name` may be a relative, private, or fully qualified service name.
+        A relative or private service is expanded using this node's namespace and name.
+        The queried service name is not remapped.
+
+        :param service_name: the service_name on which to count the number of clients.
+        :return: the number of clients on the service.
+        """
+        with self.handle:
+            return self._count_clients_or_servers(
+                service_name, self.handle.get_count_clients)
+
+    def count_services(self, service_name: str) -> int:
+        """
+        Return the number of servers on a given service.
+
+        `service_name` may be a relative, private, or fully qualified service name.
+        A relative or private service is expanded using this node's namespace and name.
+        The queried service name is not remapped.
+
+        :param service_name: the service_name on which to count the number of clients.
+        :return: the number of servers on the service.
+        """
+        with self.handle:
+            return self._count_clients_or_servers(
+                service_name, self.handle.get_count_services)
+
+    def _get_info_by_topic(
+        self,
+        topic_name: str,
+        no_mangle: bool,
+        func: Callable[[_rclpy.Node, str, bool], List['_rclpy._TopicEndpointInfoDict']]
+    ) -> List[TopicEndpointInfo]:
+        with self.handle:
+            if no_mangle:
+                fq_topic_name = topic_name
+            else:
+                fq_topic_name = expand_topic_name(
+                    topic_name, self.get_name(), self.get_namespace())
+                validate_full_topic_name(fq_topic_name)
+                fq_topic_name = _rclpy.rclpy_remap_topic_name(self.handle, fq_topic_name)
+
+            info_dicts = func(self.handle, fq_topic_name, no_mangle)
+            infos = [TopicEndpointInfo(**x) for x in info_dicts]
+            return infos
+
+    def get_publishers_info_by_topic(
+        self,
+        topic_name: str,
+        no_mangle: bool = False
+    ) -> List[TopicEndpointInfo]:
+        """
+        Return a list of publishers on a given topic.
+
+        The returned parameter is a list of TopicEndpointInfo objects, where each will contain
+        the node name, node namespace, topic type, topic endpoint's GID, and its QoS profile.
+
+        When the ``no_mangle`` parameter is ``True``, the provided ``topic_name`` should be a valid
+        topic name for the middleware (useful when combining ROS with native middleware (e.g. DDS)
+        apps).  When the ``no_mangle`` parameter is ``False``, the provided ``topic_name`` should
+        follow ROS topic name conventions.
+
+        ``topic_name`` may be a relative, private, or fully qualified topic name.
+        A relative or private topic will be expanded using this node's namespace and name.
+        The queried ``topic_name`` is not remapped.
+
+        :param topic_name: The topic_name on which to find the publishers.
+        :param no_mangle: If ``True``, ``topic_name`` needs to be a valid middleware topic
+            name, otherwise it should be a valid ROS topic name. Defaults to ``False``.
+        :return: a list of TopicEndpointInfo for all the publishers on this topic.
+        """
+        return self._get_info_by_topic(
+            topic_name,
+            no_mangle,
+            _rclpy.rclpy_get_publishers_info_by_topic)
+
+    def get_subscriptions_info_by_topic(
+        self,
+        topic_name: str,
+        no_mangle: bool = False
+    ) -> List[TopicEndpointInfo]:
+        """
+        Return a list of subscriptions on a given topic.
+
+        The returned parameter is a list of TopicEndpointInfo objects, where each will contain
+        the node name, node namespace, topic type, topic endpoint's GID, and its QoS profile.
+
+        When the ``no_mangle`` parameter is ``True``, the provided ``topic_name`` should be a valid
+        topic name for the middleware (useful when combining ROS with native middleware (e.g. DDS)
+        apps).  When the ``no_mangle`` parameter is ``False``, the provided ``topic_name`` should
+        follow ROS topic name conventions.
+
+        ``topic_name`` may be a relative, private, or fully qualified topic name.
+        A relative or private topic will be expanded using this node's namespace and name.
+        The queried ``topic_name`` is not remapped.
+
+        :param topic_name: The topic_name on which to find the subscriptions.
+        :param no_mangle: If ``True``, `topic_name` needs to be a valid middleware topic
+            name, otherwise it should be a valid ROS topic name. Defaults to ``False``.
+        :return: A list of TopicEndpointInfo for all the subscriptions on this topic.
+        """
+        return self._get_info_by_topic(
+            topic_name,
+            no_mangle,
+            _rclpy.rclpy_get_subscriptions_info_by_topic)
+
+    def _get_info_by_service(
+        self,
+        service_name: str,
+        no_mangle: bool,
+        func: Callable[[_rclpy.Node, str, bool], list[_rclpy._ServiceEndpointInfoDict]]
+    ) -> List[ServiceEndpointInfo]:
+        with self.handle:
+            if no_mangle:
+                fq_topic_name = service_name
+            else:
+                fq_topic_name = expand_topic_name(
+                    service_name, self.get_name(), self.get_namespace())
+                validate_full_topic_name(fq_topic_name)
+                fq_topic_name = _rclpy.rclpy_remap_topic_name(self.handle, fq_topic_name)
+            info_dicts = func(self.handle, fq_topic_name, no_mangle)
+            infos = [ServiceEndpointInfo(**x) for x in info_dicts]
+            return infos
+
+    def get_clients_info_by_service(
+        self,
+        service_name: str,
+        no_mangle: bool = False
+    ) -> List[ServiceEndpointInfo]:
+        """
+        Return a list of clients on a given service.
+
+        The returned parameter is a list of ServiceEndpointInfo objects, where each will contain
+        the node name, node namespace, service type, service endpoint's GIDs, and its QoS profiles.
+
+        When the ``no_mangle`` parameter is ``True``, the provided ``service_name`` should be a
+        valid service name for the middleware (useful when combining ROS with native middleware
+        apps). When the ``no_mangle`` parameter is ``False``,the provided
+        ``service_name`` should follow ROS service name conventions.
+        In DDS-based RMWs, services are implemented as topics with mangled
+        names (e.g., `rq/my_serviceRequest` and `rp/my_serviceReply`), so `no_mangle = true` is not
+        supported and will result in an error. Use `get_subscriptions_info_by_topic` or
+        get_publishers_info_by_topic` for unmangled topic queries in such cases. Other RMWs
+        (e.g., Zenoh) may support `no_mangle = true` if they natively handle
+        services without topic-based
+
+        ``service_name`` may be a relative, private, or fully qualified service name.
+        A relative or private service will be expanded using this node's namespace and name.
+        The queried ``service_name`` is not remapped.
+
+        :param service_name: The service_name on which to find the clients.
+        :param no_mangle: If ``True``, `service_name` needs to be a valid middleware service
+            name, otherwise it should be a valid ROS service name. Defaults to ``False``.
+        :return: A list of ServiceEndpointInfo for all the clients on this service.
+        """
+        return self._get_info_by_service(
+            service_name,
+            no_mangle,
+            _rclpy.rclpy_get_clients_info_by_service)
+
+    def get_servers_info_by_service(
+        self,
+        service_name: str,
+        no_mangle: bool = False
+    ) -> List[ServiceEndpointInfo]:
+        """
+        Return a list of servers on a given service.
+
+        The returned parameter is a list of ServiceEndpointInfo objects, where each will contain
+        the node name, node namespace, service type, service endpoint's GIDs, and its QoS profiles.
+
+        When the ``no_mangle`` parameter is ``True``, the provided ``service_name`` should be a
+        valid service name for the middleware (useful when combining ROS with native middleware
+        apps). When the ``no_mangle`` parameter is ``False``,the provided
+        ``service_name`` should follow ROS service name conventions.
+        In DDS-based RMWs, services are implemented as topics with mangled
+        names (e.g., `rq/my_serviceRequest` and `rp/my_serviceReply`), so `no_mangle = true` is not
+        supported and will result in an error. Use `get_subscriptions_info_by_topic` or
+        get_publishers_info_by_topic` for unmangled topic queries in such cases. Other RMWs
+        (e.g., Zenoh) may support `no_mangle = true` if they natively handle
+        services without topic-based
+
+        ``service_name`` may be a relative, private, or fully qualified service name.
+        A relative or private service will be expanded using this node's namespace and name.
+        The queried ``service_name`` is not remapped.
+
+        :param service_name: The service_name on which to find the servers.
+        :param no_mangle: If ``True``, `service_name` needs to be a valid middleware service
+            name, otherwise it should be a valid ROS service name. Defaults to ``False``.
+        :return: A list of ServiceEndpointInfo for all the servers on this service.
+        """
+        return self._get_info_by_service(
+            service_name,
+            no_mangle,
+            _rclpy.rclpy_get_servers_info_by_service)
+
+    def destroy_node(self) -> None:
+        self._parameter_event_publisher = None
+        self.handle.destroy_when_not_in_use()
+
+
+class Node(BaseNode):
+    """
+    A Node in the ROS graph.
+
+    A Node is the primary entrypoint in a ROS system for communication.
+    It can be used to create ROS entities such as publishers, subscribers, services, etc.
+    """
+
+    def __init__(
+        self,
+        node_name: str,
+        *,
+        context: Optional[Context] = None,
+        cli_args: Optional[List[str]] = None,
+        namespace: Optional[str] = None,
+        use_global_arguments: bool = True,
+        enable_rosout: bool = True,
+        rosout_qos_profile: Union[QoSProfile, int] = qos_profile_rosout_default,
+        start_parameter_services: bool = True,
+        parameter_overrides: Optional[List[Parameter[Any]]] = None,
+        allow_undeclared_parameters: bool = False,
+        automatically_declare_parameters_from_overrides: bool = False,
+        enable_logger_service: bool = False
+    ) -> None:
+        """
+        Create a Node.
+
+        :param node_name: A name to give to this node. Validated by :func:`validate_node_name`.
+        :param context: The context to be associated with, or ``None`` for the default global
+            context.
+        :param cli_args: A list of strings of command line args to be used only by this node.
+            These arguments are used to extract remappings used by the node and other ROS specific
+            settings, as well as user defined non-ROS arguments.
+        :param namespace: The namespace to which relative topic and service names will be prefixed.
+            Validated by :func:`validate_namespace`.
+        :param use_global_arguments: ``False`` if the node should ignore process-wide command line
+            args.
+        :param enable_rosout: ``False`` if the node should ignore rosout logging.
+        :param rosout_qos_profile: A QoSProfile or a history depth to apply to rosout publisher.
+            In the case that a history depth is provided, the QoS history is set to KEEP_LAST
+            the QoS history depth is set to the value of the parameter,
+            and all other QoS settings are set to their default value.
+        :param start_parameter_services: ``False`` if the node should not create parameter
+            services.
+        :param parameter_overrides: A list of overrides for initial values for parameters declared
+            on the node.
+        :param allow_undeclared_parameters: True if undeclared parameters are allowed.
+            This flag affects the behavior of parameter-related operations.
+        :param automatically_declare_parameters_from_overrides: If True, the "parameter overrides"
+            will be used to implicitly declare parameters on the node during creation.
+        :param enable_logger_service: ``True`` if ROS2 services are created to allow external nodes
+            to get and set logger levels of this node. Otherwise, logger levels are only managed
+            locally. That is, logger levels cannot be changed remotely.
+        """
+        self._publishers: List[Publisher[Any]] = []
+        self._subscriptions: List[Subscription[Any]] = []
+        self._clients: List[Client[Any, Any]] = []
+        self._services: List[Service[Any, Any]] = []
+        self._timers: List[Timer] = []
+        self._guards: List[GuardCondition] = []
+        self.__waitables: List[Waitable[Any]] = []
+        self._default_callback_group = MutuallyExclusiveCallbackGroup()
+        self._rate_group = ReentrantCallbackGroup()
+        self._clock = Clock(clock_type=ClockType.ROS_TIME)
+        self.__executor_weakref: Optional[weakref.ReferenceType[Executor]] = None
+
+        super().__init__(
+            node_name=node_name,
+            context=context,
+            cli_args=cli_args,
+            namespace=namespace,
+            use_global_arguments=use_global_arguments,
+            enable_rosout=enable_rosout,
+            rosout_qos_profile=rosout_qos_profile,
+            allow_undeclared_parameters=allow_undeclared_parameters,
+        )
+
+        self._parameter_event_publisher: Optional[Publisher[ParameterEvent]] = \
+            self.create_publisher(ParameterEvent, '/parameter_events',
+                                  qos_profile_parameter_events)
+
+        with self.handle:
+            self._parameter_overrides = self.handle.get_parameters(Parameter)
+        # Combine parameters from params files with those from the node constructor and
+        # use the set_parameters_atomically API so a parameter event is published.
+        if parameter_overrides is not None:
+            self._parameter_overrides.update({p.name: p for p in parameter_overrides})
+
+        if automatically_declare_parameters_from_overrides:
+            self.declare_parameters(
+                '',
+                [
+                    (name, param.value, ParameterDescriptor())
+                    for name, param in self._parameter_overrides.items()],
+                ignore_override=True,
+            )
+
+        # Init a time source.
+        # Note: parameter overrides and parameter event publisher need to be ready at this point
+        # to be able to declare 'use_sim_time' if it was not declared yet.
+        self._time_source = TimeSource(node=self)
+        self._time_source.attach_clock(self._clock)
+
+        if start_parameter_services:
+            self._parameter_service = ParameterService(self)
+
+        if enable_logger_service:
+            self._logger_service = LoggingService(self)
+
+        self._type_description_service = TypeDescriptionService(self)
+
+        self._context.track_node(self)
+
+    @property
+    def publishers(self) -> Iterator[Publisher[Any]]:
+        """Get publishers that have been created on this node."""
+        yield from self._publishers
+
+    @property
+    def subscriptions(self) -> Iterator[Subscription[Any]]:
+        """Get subscriptions that have been created on this node."""
+        yield from self._subscriptions
+
+    @property
+    def clients(self) -> Iterator[Client[Any, Any]]:
+        """Get clients that have been created on this node."""
+        yield from self._clients
+
+    @property
+    def services(self) -> Iterator[Service[Any, Any]]:
+        """Get services that have been created on this node."""
+        yield from self._services
+
+    @property
+    def timers(self) -> Iterator[Timer]:
+        """Get timers that have been created on this node."""
+        yield from self._timers
+
+    @property
+    def guards(self) -> Iterator[GuardCondition]:
+        """Get guards that have been created on this node."""
+        yield from self._guards
+
+    @property
+    def waitables(self) -> Iterator[Waitable[Any]]:
+        """Get waitables that have been created on this node."""
+        yield from self.__waitables
+
+    @property
+    def executor(self) -> Optional[Executor]:
+        """Get the executor if the node has been added to one, else return ``None``."""
+        if self.__executor_weakref:
+            return self.__executor_weakref()
+        return None
+
+    @executor.setter
+    def executor(self, new_executor: Optional[Executor]) -> None:
+        """Set or change the executor the node belongs to."""
+        current_executor = self.executor
+        if current_executor == new_executor:
+            return
+        if current_executor is not None:
+            current_executor.remove_node(self)
+        if new_executor is None:
+            self.__executor_weakref = None
+        else:
+            new_executor.add_node(self)
+            self.__executor_weakref = weakref.ref(new_executor)
+
+    def _wake_executor(self) -> None:
+        executor = self.executor
+        if executor:
+            executor.wake()
+
+    @property
+    def default_callback_group(self) -> CallbackGroup:
+        """
+        Get the default callback group.
+
+        If no other callback group is provided when the a ROS entity is created with the node,
+        then it is added to the default callback group.
+        """
+        return self._default_callback_group
+
+    def get_clock(self) -> Clock:
+        """Get the clock used by the node."""
+        return self._clock
+
+    def add_waitable(self, waitable: Waitable[Any]) -> None:
+        """
+        Add a class that is capable of adding things to the wait set.
+
+        :param waitable: An instance of a waitable that the node will add to the waitset.
+        """
+        self.__waitables.append(waitable)
+        self._wake_executor()
+
+    def remove_waitable(self, waitable: Waitable[Any]) -> None:
+        """
+        Remove a Waitable that was previously added to the node.
+
+        :param waitable: The Waitable to remove.
+        """
+        self.__waitables.remove(waitable)
+        self._wake_executor()
 
     def create_publisher(
         self,
@@ -2068,10 +2554,6 @@ class Node:
         """
         self._context.untrack_node(self)
 
-        # Drop extra reference to parameter event publisher.
-        # It will be destroyed with other publishers below.
-        self._parameter_event_publisher = None
-
         # Destroy dependent items eagerly to work around a possible hang
         # https://github.com/ros2/build_cop/issues/248
         while self._publishers:
@@ -2086,459 +2568,8 @@ class Node:
             self.destroy_timer(self._timers[0])
         while self._guards:
             self.destroy_guard_condition(self._guards[0])
-        self.__node.destroy_when_not_in_use()
+        super().destroy_node()
         self._wake_executor()
-
-    def get_publisher_names_and_types_by_node(
-        self,
-        node_name: str,
-        node_namespace: str,
-        no_demangle: bool = False
-    ) -> List[Tuple[str, List[str]]]:
-        """
-        Get a list of discovered topics for publishers of a remote node.
-
-        :param node_name: Name of a remote node to get publishers for.
-        :param node_namespace: Namespace of the remote node.
-        :param no_demangle: If ``True``, then topic names and types returned will not be demangled.
-        :return: List of tuples.
-          The first element of each tuple is the topic name and the second element is a list of
-          topic types.
-        :raise NodeNameNonExistentError: If the node wasn't found.
-        :raise RuntimeError: Unexpected failure.
-        """
-        with self.handle:
-            return _rclpy.rclpy_get_publisher_names_and_types_by_node(
-                self.handle, no_demangle, node_name, node_namespace)
-
-    def get_subscriber_names_and_types_by_node(
-        self,
-        node_name: str,
-        node_namespace: str,
-        no_demangle: bool = False
-    ) -> List[Tuple[str, List[str]]]:
-        """
-        Get a list of discovered topics for subscriptions of a remote node.
-
-        :param node_name: Name of a remote node to get subscriptions for.
-        :param node_namespace: Namespace of the remote node.
-        :param no_demangle: If ``True``, then topic names and types returned will not be demangled.
-        :return: List of tuples.
-          The first element of each tuple is the topic name and the second element is a list of
-          topic types.
-        :raise NodeNameNonExistentError: If the node wasn't found.
-        :raise RuntimeError: Unexpected failure.
-        """
-        with self.handle:
-            return _rclpy.rclpy_get_subscriber_names_and_types_by_node(
-                self.handle, no_demangle, node_name, node_namespace)
-
-    def get_service_names_and_types_by_node(
-        self,
-        node_name: str,
-        node_namespace: str
-    ) -> List[Tuple[str, List[str]]]:
-        """
-        Get a list of discovered service servers for a remote node.
-
-        :param node_name: Name of a remote node to get services for.
-        :param node_namespace: Namespace of the remote node.
-        :return: List of tuples.
-          The first element of each tuple is the service server name
-          and the second element is a list of service types.
-        :raise NodeNameNonExistentError: If the node wasn't found.
-        :raise RuntimeError: Unexpected failure.
-        """
-        with self.handle:
-            return _rclpy.rclpy_get_service_names_and_types_by_node(
-                self.handle, node_name, node_namespace)
-
-    def get_client_names_and_types_by_node(
-        self,
-        node_name: str,
-        node_namespace: str
-    ) -> List[Tuple[str, List[str]]]:
-        """
-        Get a list of discovered service clients for a remote node.
-
-        :param node_name: Name of a remote node to get service clients for.
-        :param node_namespace: Namespace of the remote node.
-        :return: List of tuples.
-          The first element of each tuple is the service client name
-          and the second element is a list of service client types.
-        :raise NodeNameNonExistentError: If the node wasn't found.
-        :raise RuntimeError: Unexpected failure.
-        """
-        with self.handle:
-            return _rclpy.rclpy_get_client_names_and_types_by_node(
-                self.handle, node_name, node_namespace)
-
-    def get_action_client_names_and_types_by_node(
-        self,
-        node_name: str,
-        node_namespace: str
-    ) -> List[Tuple[str, List[str]]]:
-        """
-        Get a list of action names and types for action clients associated with a remote node.
-
-        :param node_name: Name of a remote node to get action clients for.
-        :param node_namespace: Namespace of the remote node.
-        :return: List of tuples.
-          The first element of each tuple is the action name and the second element is a list of
-          action types.
-        :raise NodeNameNonExistentError: If the node wasn't found.
-        :raise RuntimeError: Unexpected failure.
-        """
-        with self.handle:
-            return _rclpy.rclpy_get_action_client_names_and_types_by_node(
-                self.handle, node_name, node_namespace)
-
-    def get_action_server_names_and_types_by_node(
-        self,
-        node_name: str,
-        node_namespace: str
-    ) -> List[Tuple[str, List[str]]]:
-        """
-        Get a list of action names and types for action servers associated with a remote node.
-
-        :param node_name: Name of a remote node to get action servers for.
-        :param node_namespace: Namespace of the remote node.
-        :return: List of tuples.
-          The first element of each tuple is the action name and the second element is a list of
-          action types.
-        :raise NodeNameNonExistentError: If the node wasn't found.
-        :raise RuntimeError: Unexpected failure.
-        """
-        with self.handle:
-            return _rclpy.rclpy_get_action_server_names_and_types_by_node(
-                self.handle, node_name, node_namespace)
-
-    def get_action_names_and_types(self) -> List[Tuple[str, List[str]]]:
-        """
-        Get a list of action names and types in the ROS graph.
-
-        :return: List of tuples.
-          The first element of each tuple is the action name and the second element is a list of
-          action types.
-        """
-        with self.handle:
-            return _rclpy.rclpy_get_action_names_and_types(self.handle)
-
-    def get_topic_names_and_types(self, no_demangle: bool = False) -> List[Tuple[str, List[str]]]:
-        """
-        Get a list of discovered topic names and types.
-
-        :param no_demangle: If ``True``, then topic names and types returned will not be demangled.
-        :return: List of tuples.
-          The first element of each tuple is the topic name and the second element is a list of
-          topic types.
-        """
-        with self.handle:
-            return _rclpy.rclpy_get_topic_names_and_types(self.handle, no_demangle)
-
-    def get_service_names_and_types(self) -> List[Tuple[str, List[str]]]:
-        """
-        Get a list of discovered service names and types.
-
-        :return: List of tuples.
-          The first element of each tuple is the service name and the second element is a list of
-          service types.
-        """
-        with self.handle:
-            return _rclpy.rclpy_get_service_names_and_types(self.handle)
-
-    def get_node_names(self) -> List[str]:
-        """
-        Get a list of names for discovered nodes.
-
-        :return: List of node names.
-        """
-        with self.handle:
-            names_ns = self.handle.get_node_names_and_namespaces()
-        return [n[0] for n in names_ns]
-
-    def get_fully_qualified_node_names(self) -> List[str]:
-        """
-        Get a list of fully qualified names for discovered nodes.
-
-        Similar to ``get_node_names_namespaces()``, but concatenates the names and namespaces.
-
-        :return: List of fully qualified node names.
-        """
-        names_and_namespaces = self.get_node_names_and_namespaces()
-        return [
-            ns + ('' if ns.endswith('/') else '/') + name
-            for name, ns in names_and_namespaces
-        ]
-
-    def get_node_names_and_namespaces(self) -> List[Tuple[str, str]]:
-        """
-        Get a list of names and namespaces for discovered nodes.
-
-        :return: List of tuples containing two strings: the node name and node namespace.
-        """
-        with self.handle:
-            return self.handle.get_node_names_and_namespaces()
-
-    def get_node_names_and_namespaces_with_enclaves(self) -> List[Tuple[str, str, str]]:
-        """
-        Get a list of names, namespaces and enclaves for discovered nodes.
-
-        :return: List of tuples containing three strings: the node name, node namespace
-            and enclave.
-        """
-        with self.handle:
-            return self.handle.get_node_names_and_namespaces_with_enclaves()
-
-    def get_fully_qualified_name(self) -> str:
-        """
-        Get the node's fully qualified name.
-
-        :return: Fully qualified node name.
-        """
-        with self.handle:
-            return self.handle.get_fully_qualified_name()
-
-    def _count_publishers_or_subscribers(self, topic_name: str, func: Callable[[str], int]) -> int:
-        fq_topic_name = expand_topic_name(topic_name, self.get_name(), self.get_namespace())
-        validate_full_topic_name(fq_topic_name)
-        with self.handle:
-            return func(fq_topic_name)
-
-    def count_publishers(self, topic_name: str) -> int:
-        """
-        Return the number of publishers on a given topic.
-
-        ``topic_name`` may be a relative, private, or fully qualified topic name.
-        A relative or private topic is expanded using this node's namespace and name.
-        The queried topic name is not remapped.
-
-        :param topic_name: The topic name on which to count the number of publishers.
-        :return: The number of publishers on the topic.
-        """
-        with self.handle:
-            return self._count_publishers_or_subscribers(
-                topic_name, self.handle.get_count_publishers)
-
-    def count_subscribers(self, topic_name: str) -> int:
-        """
-        Return the number of subscribers on a given topic.
-
-        ``topic_name`` may be a relative, private, or fully qualified topic name.
-        A relative or private topic is expanded using this node's namespace and name.
-        The queried topic name is not remapped.
-
-        :param topic_name: The topic name on which to count the number of subscribers.
-        :return: The number of subscribers on the topic.
-        """
-        with self.handle:
-            return self._count_publishers_or_subscribers(
-                topic_name, self.handle.get_count_subscribers)
-
-    def _count_clients_or_servers(self, service_name: str, func: Callable[[str], int]) -> int:
-        fq_service_name = expand_topic_name(service_name, self.get_name(), self.get_namespace())
-        validate_full_topic_name(fq_service_name, is_service=True)
-        with self.handle:
-            return func(fq_service_name)
-
-    def count_clients(self, service_name: str) -> int:
-        """
-        Return the number of clients on a given service.
-
-        `service_name` may be a relative, private, or fully qualified service name.
-        A relative or private service is expanded using this node's namespace and name.
-        The queried service name is not remapped.
-
-        :param service_name: the service_name on which to count the number of clients.
-        :return: the number of clients on the service.
-        """
-        with self.handle:
-            return self._count_clients_or_servers(
-                service_name, self.handle.get_count_clients)
-
-    def count_services(self, service_name: str) -> int:
-        """
-        Return the number of servers on a given service.
-
-        `service_name` may be a relative, private, or fully qualified service name.
-        A relative or private service is expanded using this node's namespace and name.
-        The queried service name is not remapped.
-
-        :param service_name: the service_name on which to count the number of clients.
-        :return: the number of servers on the service.
-        """
-        with self.handle:
-            return self._count_clients_or_servers(
-                service_name, self.handle.get_count_services)
-
-    def _get_info_by_topic(
-        self,
-        topic_name: str,
-        no_mangle: bool,
-        func: Callable[[_rclpy.Node, str, bool], List['_rclpy._TopicEndpointInfoDict']]
-    ) -> List[TopicEndpointInfo]:
-        with self.handle:
-            if no_mangle:
-                fq_topic_name = topic_name
-            else:
-                fq_topic_name = expand_topic_name(
-                    topic_name, self.get_name(), self.get_namespace())
-                validate_full_topic_name(fq_topic_name)
-                fq_topic_name = _rclpy.rclpy_remap_topic_name(self.handle, fq_topic_name)
-
-            info_dicts = func(self.handle, fq_topic_name, no_mangle)
-            infos = [TopicEndpointInfo(**x) for x in info_dicts]
-            return infos
-
-    def get_publishers_info_by_topic(
-        self,
-        topic_name: str,
-        no_mangle: bool = False
-    ) -> List[TopicEndpointInfo]:
-        """
-        Return a list of publishers on a given topic.
-
-        The returned parameter is a list of TopicEndpointInfo objects, where each will contain
-        the node name, node namespace, topic type, topic endpoint's GID, and its QoS profile.
-
-        When the ``no_mangle`` parameter is ``True``, the provided ``topic_name`` should be a valid
-        topic name for the middleware (useful when combining ROS with native middleware (e.g. DDS)
-        apps).  When the ``no_mangle`` parameter is ``False``, the provided ``topic_name`` should
-        follow ROS topic name conventions.
-
-        ``topic_name`` may be a relative, private, or fully qualified topic name.
-        A relative or private topic will be expanded using this node's namespace and name.
-        The queried ``topic_name`` is not remapped.
-
-        :param topic_name: The topic_name on which to find the publishers.
-        :param no_mangle: If ``True``, ``topic_name`` needs to be a valid middleware topic
-            name, otherwise it should be a valid ROS topic name. Defaults to ``False``.
-        :return: a list of TopicEndpointInfo for all the publishers on this topic.
-        """
-        return self._get_info_by_topic(
-            topic_name,
-            no_mangle,
-            _rclpy.rclpy_get_publishers_info_by_topic)
-
-    def get_subscriptions_info_by_topic(
-        self,
-        topic_name: str,
-        no_mangle: bool = False
-    ) -> List[TopicEndpointInfo]:
-        """
-        Return a list of subscriptions on a given topic.
-
-        The returned parameter is a list of TopicEndpointInfo objects, where each will contain
-        the node name, node namespace, topic type, topic endpoint's GID, and its QoS profile.
-
-        When the ``no_mangle`` parameter is ``True``, the provided ``topic_name`` should be a valid
-        topic name for the middleware (useful when combining ROS with native middleware (e.g. DDS)
-        apps).  When the ``no_mangle`` parameter is ``False``, the provided ``topic_name`` should
-        follow ROS topic name conventions.
-
-        ``topic_name`` may be a relative, private, or fully qualified topic name.
-        A relative or private topic will be expanded using this node's namespace and name.
-        The queried ``topic_name`` is not remapped.
-
-        :param topic_name: The topic_name on which to find the subscriptions.
-        :param no_mangle: If ``True``, `topic_name` needs to be a valid middleware topic
-            name, otherwise it should be a valid ROS topic name. Defaults to ``False``.
-        :return: A list of TopicEndpointInfo for all the subscriptions on this topic.
-        """
-        return self._get_info_by_topic(
-            topic_name,
-            no_mangle,
-            _rclpy.rclpy_get_subscriptions_info_by_topic)
-
-    def _get_info_by_service(
-        self,
-        service_name: str,
-        no_mangle: bool,
-        func: Callable[[_rclpy.Node, str, bool], list[_rclpy._ServiceEndpointInfoDict]]
-    ) -> List[ServiceEndpointInfo]:
-        with self.handle:
-            if no_mangle:
-                fq_topic_name = service_name
-            else:
-                fq_topic_name = expand_topic_name(
-                    service_name, self.get_name(), self.get_namespace())
-                validate_full_topic_name(fq_topic_name)
-                fq_topic_name = _rclpy.rclpy_remap_topic_name(self.handle, fq_topic_name)
-            info_dicts = func(self.handle, fq_topic_name, no_mangle)
-            infos = [ServiceEndpointInfo(**x) for x in info_dicts]
-            return infos
-
-    def get_clients_info_by_service(
-        self,
-        service_name: str,
-        no_mangle: bool = False
-    ) -> List[ServiceEndpointInfo]:
-        """
-        Return a list of clients on a given service.
-
-        The returned parameter is a list of ServiceEndpointInfo objects, where each will contain
-        the node name, node namespace, service type, service endpoint's GIDs, and its QoS profiles.
-
-        When the ``no_mangle`` parameter is ``True``, the provided ``service_name`` should be a
-        valid service name for the middleware (useful when combining ROS with native middleware
-        apps). When the ``no_mangle`` parameter is ``False``,the provided
-        ``service_name`` should follow ROS service name conventions.
-        In DDS-based RMWs, services are implemented as topics with mangled
-        names (e.g., `rq/my_serviceRequest` and `rp/my_serviceReply`), so `no_mangle = true` is not
-        supported and will result in an error. Use `get_subscriptions_info_by_topic` or
-        get_publishers_info_by_topic` for unmangled topic queries in such cases. Other RMWs
-        (e.g., Zenoh) may support `no_mangle = true` if they natively handle
-        services without topic-based
-
-        ``service_name`` may be a relative, private, or fully qualified service name.
-        A relative or private service will be expanded using this node's namespace and name.
-        The queried ``service_name`` is not remapped.
-
-        :param service_name: The service_name on which to find the clients.
-        :param no_mangle: If ``True``, `service_name` needs to be a valid middleware service
-            name, otherwise it should be a valid ROS service name. Defaults to ``False``.
-        :return: A list of ServiceEndpointInfo for all the clients on this service.
-        """
-        return self._get_info_by_service(
-            service_name,
-            no_mangle,
-            _rclpy.rclpy_get_clients_info_by_service)
-
-    def get_servers_info_by_service(
-        self,
-        service_name: str,
-        no_mangle: bool = False
-    ) -> List[ServiceEndpointInfo]:
-        """
-        Return a list of servers on a given service.
-
-        The returned parameter is a list of ServiceEndpointInfo objects, where each will contain
-        the node name, node namespace, service type, service endpoint's GIDs, and its QoS profiles.
-
-        When the ``no_mangle`` parameter is ``True``, the provided ``service_name`` should be a
-        valid service name for the middleware (useful when combining ROS with native middleware
-        apps). When the ``no_mangle`` parameter is ``False``,the provided
-        ``service_name`` should follow ROS service name conventions.
-        In DDS-based RMWs, services are implemented as topics with mangled
-        names (e.g., `rq/my_serviceRequest` and `rp/my_serviceReply`), so `no_mangle = true` is not
-        supported and will result in an error. Use `get_subscriptions_info_by_topic` or
-        get_publishers_info_by_topic` for unmangled topic queries in such cases. Other RMWs
-        (e.g., Zenoh) may support `no_mangle = true` if they natively handle
-        services without topic-based
-
-        ``service_name`` may be a relative, private, or fully qualified service name.
-        A relative or private service will be expanded using this node's namespace and name.
-        The queried ``service_name`` is not remapped.
-
-        :param service_name: The service_name on which to find the servers.
-        :param no_mangle: If ``True``, `service_name` needs to be a valid middleware service
-            name, otherwise it should be a valid ROS service name. Defaults to ``False``.
-        :return: A list of ServiceEndpointInfo for all the servers on this service.
-        """
-        return self._get_info_by_service(
-            service_name,
-            no_mangle,
-            _rclpy.rclpy_get_servers_info_by_service)
 
     def wait_for_node(
         self,

--- a/rclpy/rclpy/parameter_service.py
+++ b/rclpy/rclpy/parameter_service.py
@@ -26,12 +26,12 @@ from rclpy.qos import qos_profile_parameters
 from rclpy.validate_topic_name import TOPIC_SEPARATOR_STRING
 
 if TYPE_CHECKING:
-    from rclpy.node import Node
+    from rclpy.node import BaseNode
 
 
 class ParameterService:
 
-    def __init__(self, node: 'Node'):
+    def __init__(self, node: 'BaseNode'):
         self._node_weak_ref = weakref.ref(node)
         nodename = node.get_name()
 
@@ -166,7 +166,7 @@ class ParameterService:
                 )
         return response
 
-    def _get_node(self) -> 'Node':
+    def _get_node(self) -> 'BaseNode':
         node = self._node_weak_ref()
         if node is None:
             raise ReferenceError('Expected valid node weak reference')

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -25,8 +25,8 @@ from rclpy.time import Time
 import rosgraph_msgs.msg
 
 if TYPE_CHECKING:
-    from rclpy.node import Node
-    from rclpy.subscription import Subscription
+    from rclpy.node import BaseNode
+    from rclpy.subscription import BaseSubscription
 
 CLOCK_TOPIC = '/clock'
 USE_SIM_TIME_NAME = 'use_sim_time'
@@ -34,9 +34,9 @@ USE_SIM_TIME_NAME = 'use_sim_time'
 
 class TimeSource:
 
-    def __init__(self, *, node: Optional['Node'] = None):
-        self._clock_sub: Optional['Subscription[rosgraph_msgs.msg.Clock]'] = None
-        self._node_weak_ref: Optional[weakref.ReferenceType['Node']] = None
+    def __init__(self, *, node: Optional['BaseNode'] = None):
+        self._clock_sub: Optional['BaseSubscription[rosgraph_msgs.msg.Clock]'] = None
+        self._node_weak_ref: Optional[weakref.ReferenceType['BaseNode']] = None
         self._associated_clocks: Set[BaseClock] = set()
         # Zero time is a special value that means time is uninitialized
         self._last_time_set = Time(clock_type=ClockType.ROS_TIME)
@@ -59,10 +59,8 @@ class TimeSource:
             self._subscribe_to_clock_topic()
         else:
             if self._clock_sub is not None:
-                node = self._get_node()
-                if node is not None:
-                    node.destroy_subscription(self._clock_sub)
-                    self._clock_sub = None
+                self._clock_sub.destroy()
+                self._clock_sub = None
 
     def _subscribe_to_clock_topic(self) -> None:
         if self._clock_sub is None:
@@ -75,10 +73,10 @@ class TimeSource:
                     QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT)
                 )
 
-    def attach_node(self, node: 'Node') -> None:
-        from rclpy.node import Node
-        if not isinstance(node, Node):
-            raise TypeError('Node must be of type rclpy.node.Node')
+    def attach_node(self, node: 'BaseNode') -> None:
+        from rclpy.node import BaseNode
+        if not isinstance(node, BaseNode):
+            raise TypeError('Node must be of type rclpy.node.BaseNode')
         # Remove an existing node.
         if self._node_weak_ref is not None:
             self.detach_node()
@@ -105,10 +103,7 @@ class TimeSource:
     def detach_node(self) -> None:
         # Remove the subscription to the clock topic.
         if self._clock_sub is not None:
-            node = self._get_node()
-            if node is None:
-                raise RuntimeError('Unable to destroy previously created clock subscription')
-            node.destroy_subscription(self._clock_sub)
+            self._clock_sub.destroy()
         self._clock_sub = None
         self._node_weak_ref = None
 
@@ -147,7 +142,7 @@ class TimeSource:
 
         return SetParametersResult(successful=successful, reason=reason)
 
-    def _get_node(self) -> Optional['Node']:
+    def _get_node(self) -> Optional['BaseNode']:
         if self._node_weak_ref is not None:
             return self._node_weak_ref()
         return None

--- a/rclpy/rclpy/type_description_service.py
+++ b/rclpy/rclpy/type_description_service.py
@@ -21,14 +21,13 @@ from rcl_interfaces.msg import ParameterType
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.parameter import Parameter
 from rclpy.qos import qos_profile_services_default
-from rclpy.service import Service
 from rclpy.type_support import check_is_valid_srv_type
 from rclpy.validate_topic_name import TOPIC_SEPARATOR_STRING
 
 from type_description_interfaces.srv import GetTypeDescription
 
 if TYPE_CHECKING:
-    from rclpy.node import Node
+    from rclpy.node import BaseNode
 
 START_TYPE_DESCRIPTION_SERVICE_PARAM = 'start_type_description_service'
 
@@ -40,10 +39,10 @@ class TypeDescriptionService:
     The service is implemented in rcl, but should be enabled via parameter and have its
     callbacks handled via end-client execution framework, such as callback groups and waitsets.
 
-    This is not intended for use by end users, rather it is a component to be used by Node.
+    This is not intended for use by end users, rather it is a component to be used by BaseNode.
     """
 
-    def __init__(self, node: 'Node'):
+    def __init__(self, node: 'BaseNode'):
         """Initialize the service, if the parameter is set to true."""
         self._node_weak_ref = weakref.ref(node)
         node_name = node.get_name()
@@ -80,20 +79,13 @@ class TypeDescriptionService:
     def _start_service(self) -> None:
         node = self._get_node()
         self._type_description_srv = _rclpy.TypeDescriptionService(node.handle)
-        # Because we are creating our own service wrapper, must manually add the service
-        # to the appropriate parts of Node because we cannot call create_service.
         check_is_valid_srv_type(GetTypeDescription)
-        service = Service(
-            service_impl=self._type_description_srv.impl,
-            srv_type=GetTypeDescription,
-            srv_name=self.service_name,
-            callback=self._service_callback,
-            on_destroy=node._on_destroy_service,
-            callback_group=node.default_callback_group,
-            qos_profile=qos_profile_services_default)
-        node.default_callback_group.add_entity(service)
-        node._services.append(service)
-        node._wake_executor()
+        node._create_service(
+            self._type_description_srv.impl,
+            GetTypeDescription,
+            self.service_name,
+            self._service_callback,
+            qos_profile_services_default)
 
     def _service_callback(
         self,
@@ -105,7 +97,7 @@ class TypeDescriptionService:
         return self._type_description_srv.handle_request(
             request, GetTypeDescription.Response, self._get_node().handle)
 
-    def _get_node(self) -> 'Node':
+    def _get_node(self) -> 'BaseNode':
         node = self._node_weak_ref()
         if node is None:
             raise ReferenceError('Expected valid node weak reference')


### PR DESCRIPTION
Part of #1620

## Changes

* Moved `BaseNode` initialization logic from `Node.__init__` into `BaseNode.__init__`
* Added abstract methods on `BaseNode` (`create_publisher`, `create_subscription`, `create_service`, `_create_service`) so BaseNode can construct the parameter event publisher, parameter services and type description service
* Extracted handle creation methods into `BaseNode` (`_create_publisher_handle`, `_create_subscription_handle`, `_create_service_handle`, `_create_client_handle`)
* `TimeSource`, `ParameterService`, `LoggingService`, `TypeDescriptionService` retyped to accept `BaseNode` instead of `Node`
* `TimeSource._clock_sub` cleans itself up via `self._clock_sub.destroy()` instead of `node.destroy_subscription(...)` to decouple from `Node`'s entity lists
* `TypeDescriptionService._start_service` now calls `node._create_service(...)` instead of directly constructing a `Service`
* `TimeSource.attach_clock` is called with `self.get_clock()` in `BaseNode.__init__` instead of `self._clock`
* `Node.destroy_node()` no longer calls `self._type_description_service.destroy()` explicitly and is destroyed by the entity teardown loop in Node.destroy_node() instead
